### PR TITLE
Add support for overriding DESCOPE_BASE_URL by setting a GitHub variable

### DIFF
--- a/.github/workflows/create-pullreq.yml
+++ b/.github/workflows/create-pullreq.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           project_id: ${{ inputs.project_id }}
           management_key: ${{ secrets.management_key }}
+          descope_base_url: ${{ vars.DESCOPE_BASE_URL }}
           files_path: ${{ env.FILES_PATH }}
 
       - name: Cancel If No Changes

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           project_id: ${{ vars.PRODUCTION_PROJECT_ID }}
           management_key: ${{ secrets.PRODUCTION_MANAGEMENT_KEY || secrets.MANAGEMENT_KEY }}
+          descope_base_url: ${{ vars.DESCOPE_BASE_URL }}
           files_path: ${{ env.FILES_PATH }}
           secrets: ${{ inputs.secrets }}
           validate_only: true
@@ -124,6 +125,7 @@ jobs:
         with:
           project_id: ${{ vars.PRODUCTION_PROJECT_ID }}
           management_key: ${{ secrets.PRODUCTION_MANAGEMENT_KEY || secrets.MANAGEMENT_KEY }}
+          descope_base_url: ${{ vars.DESCOPE_BASE_URL }}
           files_path: ${{ env.FILES_PATH }}
           secrets: ${{ inputs.secrets }}
           import_only: true

--- a/extras/modify-files/create-pullreq.yml
+++ b/extras/modify-files/create-pullreq.yml
@@ -43,8 +43,8 @@ jobs:
         with:
           project_id: ${{ inputs.project_id }}
           management_key: ${{ secrets.management_key }}
-          files_path: ${{ env.FILES_PATH }}
           descope_base_url: ${{ vars.DESCOPE_BASE_URL }}
+          files_path: ${{ env.FILES_PATH }}
       
       - name: Process Snapshot
         if: steps.export.outputs.changes_file != ''

--- a/extras/modify-files/create-pullreq.yml
+++ b/extras/modify-files/create-pullreq.yml
@@ -44,6 +44,7 @@ jobs:
           project_id: ${{ inputs.project_id }}
           management_key: ${{ secrets.management_key }}
           files_path: ${{ env.FILES_PATH }}
+          descope_base_url: ${{ vars.DESCOPE_BASE_URL }}
       
       - name: Process Snapshot
         if: steps.export.outputs.changes_file != ''


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/14748

## Description
- Add support for overriding `DESCOPE_BASE_URL` by setting a GitHub variable.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)
